### PR TITLE
Support github URLs with a hash

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -580,7 +580,7 @@ fn extract_github_url(message: &str,
                       -> (Option<Option<String>>, Option<String>) {
     lazy_static! {
         static ref GITHUB_URL_WHOLE_RE: Regex =
-            Regex::new(r"^https://github.com/(?P<repo>[^/]*/[^/]*)/issues/(?P<number>[0-9]+)$")
+            Regex::new(r"^https://github.com/(?P<repo>[^/]*/[^/]*)/issues/(?P<number>[0-9]+)(?:#|$)")
             .unwrap();
         static ref GITHUB_URL_PART_RE: Regex =
             Regex::new(r"https://github.com/(?P<repo>[^/]*/[^/]*)/issues/(?P<number>[0-9]+)")


### PR DESCRIPTION
See https://logs.csswg.org/irc.w3.org/css/2017-05-10/#e806942

---

Note: I have not tested this.