### PR TITLE
Add TTWG IRC channel and repos

### DIFF
--- a/src/config.json
+++ b/src/config.json
@@ -8,11 +8,11 @@
   "port": 6667,
   "use_ssl": false,
   "encoding": "UTF-8",
-  "channels": ["#css", "#fx", "#houdini"],
+  "channels": ["#css", "#fx", "#houdini", "#tt"],
   "user_info": "Bot to add meeting minutes to github issues.",
   "options": {
     "source": "https://github.com/dbaron/wgmeeting-github-ircbot",
-    "github_repos_allowed": "w3c/csswg-drafts w3c/fxtf-drafts w3c/css-houdini-drafts w3c/svgwg w3c/web-platform-tests",
+    "github_repos_allowed": "w3c/csswg-drafts w3c/fxtf-drafts w3c/css-houdini-drafts w3c/svgwg w3c/web-platform-tests w3c/imsc w3c/ttml1 w3c/ttml2 w3c/imsc-tests w3c/tt-profile-registry w3c/webvtt w3c/png-hdr-pq",
     "github_access_token": "<ACCESS TOKEN HERE>",
     "github_uastring": "wgmeeting-github-ircbot/0.1.0"
   }


### PR DESCRIPTION
As discussed by private email with @dbaron a few weeks back, changes needed so this bot can also be used for TTWG.