### PR TITLE
Add Open UI group and repository

### DIFF
--- a/src/config.toml
+++ b/src/config.toml
@@ -184,3 +184,9 @@ github_repos_allowed = [
     "w3c/epub-wg",
     "w3c/publ-epub-revision",
 ]
+
+[channels."#openui"]
+group = "Open UI Community Group"
+github_repos_allowed = [
+    "openui/open-ui",
+]


### PR DESCRIPTION
Hi! 

We would like to use the meetingbot for Open UI meetings if possible!  

Hope it's okay to add a outside the W3C org. [Open UI](https://open-ui.org/) is a W3C Community Group

(reference https://github.com/openui/open-ui/issues/376)