### PR TITLE
Add #matf

### DIFF
--- a/src/config.toml
+++ b/src/config.toml
@@ -215,3 +215,9 @@ github_repos_allowed = [
     "w3c/virtual-keyboard",
     "w3c/edit-context",
 ]
+
+[channels."#matf"]
+group = "Mobile Accessibility Task Force"
+github_repos_allowed = [
+    "w3c/matf",
+]


### PR DESCRIPTION
Hi David,

We'd like to use the CSS meeting bot for the [Mobile Accessibility Task Force](https://www.w3.org/WAI/GL/task-forces/matf/) of the Accessibility Guidelines Working Group please! 

Thanks! (cc @JJDeGroot)