### PR TITLE
Add web components community group

### DIFF
--- a/src/config.toml
+++ b/src/config.toml
@@ -231,3 +231,11 @@ group = "Mobile Accessibility Task Force"
 github_repos_allowed = [
     "w3c/matf",
 ]
+
+
+[channels."#webcomponents"]
+group = "Web Components Community Group"
+github_repos_allowed = [
+    "WICG/webcomponents",
+    "whatwg/html",
+]


### PR DESCRIPTION
I think I've done this right. The intent is for the #webcomponents IRC channel to be able to invite & use github-bot.